### PR TITLE
[CG-47] Add sleep + attempts on rebalance for unknown topic/partition error

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -869,7 +869,7 @@ func (r *Reader) run() {
 
 	for {
 		if attempt >= 5 {
-			log.Fatal("Cannot find topic or partition")
+			panic(fmt.Sprintf("unknown topic %v or partition %v", r.config.Topic, r.config.Partition))
 		}
 
 		if err := r.handshake(); err != nil {

--- a/reader.go
+++ b/reader.go
@@ -873,6 +873,9 @@ func (r *Reader) run() {
 		}
 
 		if err := r.handshake(); err != nil {
+			// This error happens when:
+			// 1. The topic doesn't exist, `joinGroup` throws this error
+			// 2. More consumers are started than the number of partitions, `syncGroup` throws this error
 			if err == UnknownTopicOrPartition {
 				unknownTopicPartitionErrCount++
 				sleepSecs *= 2

--- a/reader.go
+++ b/reader.go
@@ -864,17 +864,17 @@ func (r *Reader) run() {
 		l.Printf("entering loop for consumer group, %v\n", r.config.GroupID)
 	})
 
-	attempt := 0
+	unknownTopicPartitionErrCount := 0
 	sleepSecs := time.Second
 
 	for {
-		if attempt >= 5 {
+		if unknownTopicPartitionErrCount >= 5 {
 			panic(fmt.Sprintf("unknown topic %v or partition %v", r.config.Topic, r.config.Partition))
 		}
 
 		if err := r.handshake(); err != nil {
 			if err == UnknownTopicOrPartition {
-				attempt++
+				unknownTopicPartitionErrCount++
 				sleepSecs *= 2
 			}
 


### PR DESCRIPTION
# Changes
 - Introduces an e backoff on sleep when UnknownTopicorPartition error is encountered, panics on 5th attempt
    - This will cause the service to restart
 - Introduces a minimum 1s sleep on the handshake for loop